### PR TITLE
manually install imagemagick in GitHub actions to fix webp generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
           value: ${{ github.repository }}
       - name: Install and Build 🔧
         run: |
+          sudo apt-get update && sudo apt-get install -y imagemagick
           pip3 install --upgrade jupyter
           export JEKYLL_ENV=production
           bundle exec jekyll build --lsi


### PR DESCRIPTION
GitHub removed imagemagick from their pre-installed software list. Pulling this fix from the Al-folio branch, which I am behind to address this issue